### PR TITLE
Update micromatch dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "detect-file": "^1.0.0",
     "is-glob": "^4.0.0",
-    "micromatch": "^3.0.4",
+    "micromatch": "^4.0.0",
     "resolve-dir": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes: #46

`micromatch` v3 has multiple security vulnerabilities that were fixed with v4.

[Changelog](https://github.com/micromatch/micromatch/blob/master/CHANGELOG.md#400---2019-03-20)