### PR TITLE
fix(security): closes #48

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "detect-file": "^1.0.0",
     "is-glob": "^4.0.0",
-    "micromatch": "^3.0.4",
+    "micromatch": "^4.0.2",
     "resolve-dir": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Micromatch must be updated to a newer version to fix a vulnerability. Unit tests are passing with the new version of micromatch.