### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 sudo: false
+arch:
+  - amd64
+  - ppc64le
 language: node_js
 os:
   - linux


### PR DESCRIPTION
Hi,
I had added ppc64le support on Travis-ci and Its been success added and build. Kindly review and merge same.

Changes done are added ppc64le arch.

The Travis ci build logs can be verified from the link below.
https://travis-ci.com/github/zazzel/findup-sync
Please have a look.

Thank you